### PR TITLE
Fix versioning for Gradle tests

### DIFF
--- a/gradle-tests/build.gradle
+++ b/gradle-tests/build.gradle
@@ -73,7 +73,7 @@ subprojects {
     dependencies {
         compile ('jakarta.enterprise:jakarta.enterprise.cdi-api:3.0.0')
        
-        testCompile group: "io.openliberty.arquillian", name: "arquillian-liberty-managed-jakarta-junit", version: "2.0.0-SNAPSHOT"
+        testCompile group: "io.openliberty.arquillian", name: "arquillian-liberty-managed-jakarta-junit", version: dependencyBundleVersion
         testCompile ('org.jboss.shrinkwrap:shrinkwrap-api')
         testCompile files("${System.properties['java.home']}/../lib/tools.jar")
     }

--- a/gradle-tests/gradle.properties
+++ b/gradle-tests/gradle.properties
@@ -1,1 +1,1 @@
-dependencyBundleVersion=2.0.0-SNAPSHOT
+dependencyBundleVersion=2.0.1-SNAPSHOT


### PR DESCRIPTION
Use the `dependencyBundleVersion` parameter in the `build.gradle` of the Gradle test project, the variable should be populated by the corresponding `gradle.properties` file, which is generated when the project is built.

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>