### PR TITLE
Update dependencies for arquillian, liberty and liberty plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Liberty dependency bundles for Arquillian make it easy for you to manage ver
 
 ## Dependencies
 
-In this repository, you'll find 6 artifacts that you can use in your Maven and Gradle projects with Jakarta EE 9. They are:
+In this repository, you'll find 6 artifacts that you can use in your Maven and Gradle projects with Jakarta EE 9 and 10. They are:
 
 - `io.openliberty.arquillian:arquillian-liberty-managed-jakarta-junit` for using the Arquillian Liberty Managed container with JUnit
 - `io.openliberty.arquillian:arquillian-liberty-managed-jakarta-junit5` for using the Arquillian Liberty Managed container with JUnit5
@@ -28,14 +28,14 @@ For Java EE 8 or below, the following 4 artifacts are available:
 
 In order to prevent dependency conflicts, you'll need to use the `arquillian-bom` in conjunction with a dependency bundle. While the `arquillian-liberty-dependencies` parent POM already contains the `arquillian-bom`, this is used only to build the dependency bundle artifacts and will not be applied to your project when you include them. The version of the `arquillian-bom` that you specify will apply to transitive dependencies of your project. 
 
-**Jakarta EE 9 example:**
+**Jakarta EE 9 and 10 example:**
 ```
 <dependencyManagement>
 	<dependencies>
 		<dependency>
 			<groupId>org.jboss.arquillian</groupId>
 			<artifactId>arquillian-bom</artifactId>
-			<version>1.7.0.Alpha14</version>
+			<version>1.7.0.Final</version>
 			<scope>import</scope>
 			<type>pom</type>
 		</dependency>
@@ -47,7 +47,7 @@ In order to prevent dependency conflicts, you'll need to use the `arquillian-bom
 	<dependency>
 		<groupId>io.openliberty.arquillian</groupId>
 		<artifactId>arquillian-liberty-managed-jakarta-junit</artifactId>
-		<version>2.1.2</version>
+		<version>2.1.4</version>
 		<type>pom</type>
 		<scope>test</scope>
 	</dependency>
@@ -119,11 +119,11 @@ Step 3: Add a `dependencyManagement` block that contains the `arquillian-bom`:
 ```
 dependencyManagement {
     imports {
-        mavenBom "org.jboss.arquillian:arquillian-bom:1.7.0.Alpha14"
+        mavenBom "org.jboss.arquillian:arquillian-bom:1.7.0.Final"
     }
 }
 ```
 
 You can use the command `gradle dependencies` to view transitive dependencies and their versions. 
 
-The previous example uses version `1.7.0.Alpha14` of the `arquillian-bom` for Jakarta EE 9 projects. If using Java EE 8 or below, use version `1.1.13.Final` of the `arquillian-bom`. A full Gradle example with Jakarta EE 9 is available in the `gradle-tests` folder.
+The previous example uses version `1.7.0.Final` of the `arquillian-bom` for Jakarta EE 9 and 10 projects. If using Java EE 8 or below, use version `1.1.13.Final` of the `arquillian-bom`. A full Gradle example with Jakarta EE 9 is available in the `gradle-tests` folder.

--- a/gradle-tests/build.gradle
+++ b/gradle-tests/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath group: 'io.openliberty.tools', name: 'liberty-gradle-plugin', version: '3.5.1'
+        classpath group: 'io.openliberty.tools', name: 'liberty-gradle-plugin', version: '3.6.1'
         classpath "io.spring.gradle:dependency-management-plugin:1.0.4.RELEASE"
     }
 }
@@ -23,7 +23,7 @@ subprojects {
             mavenCentral()
         }
         dependencies {
-            classpath group: 'io.openliberty.tools', name: 'liberty-gradle-plugin', version: '3.5.1'
+            classpath group: 'io.openliberty.tools', name: 'liberty-gradle-plugin', version: '3.6.1'
             classpath "io.spring.gradle:dependency-management-plugin:1.0.4.RELEASE"
         }
     }
@@ -66,7 +66,7 @@ subprojects {
 
     dependencyManagement {
         imports {
-            mavenBom "org.jboss.arquillian:arquillian-bom:1.7.0.Alpha14"
+            mavenBom "org.jboss.arquillian:arquillian-bom:1.7.0.Final"
         }
     }
 

--- a/gradle-tests/gradle.properties
+++ b/gradle-tests/gradle.properties
@@ -1,1 +1,1 @@
-dependencyBundleVersion=2.1.3-SNAPSHOT
+dependencyBundleVersion=2.1.4-SNAPSHOT

--- a/gradle-tests/olTest/build.gradle
+++ b/gradle-tests/olTest/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    libertyRuntime group: 'io.openliberty', name: 'openliberty-runtime', version: '22.0.0.12'
+    libertyRuntime group: 'io.openliberty', name: 'openliberty-runtime', version: '23.0.0.3'
 }

--- a/gradle-tests/wlpTest/build.gradle
+++ b/gradle-tests/wlpTest/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    libertyRuntime group: 'com.ibm.websphere.appserver.runtime', name: 'wlp-webProfile9', version: '22.0.0.12'
+    libertyRuntime group: 'com.ibm.websphere.appserver.runtime', name: 'wlp-webProfile9', version: '23.0.0.2'
 }

--- a/it/managed-tests/pom.xml
+++ b/it/managed-tests/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>io.openliberty.tools</groupId>
         <artifactId>liberty-maven-app-parent</artifactId>
-        <version>3.7.1</version>
+        <version>3.8.1</version>
     </parent>
 
     <licenses>
@@ -62,7 +62,7 @@
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
-                <version>1.7.0.Alpha14</version>
+                <version>1.7.0.Final</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -145,7 +145,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.7.1</version>
+                <version>3.8.1</version>
                 <extensions>true</extensions>
                 <!-- Specify configuration, executions for liberty-maven-plugin -->
                 <configuration>
@@ -255,7 +255,7 @@
             <properties>
                 <runtimeGroupId>com.ibm.websphere.appserver.runtime</runtimeGroupId>
                 <runtimeArtifactId>wlp-webProfile9</runtimeArtifactId>
-                <runtimeVersion>22.0.0.9</runtimeVersion>
+                <runtimeVersion>23.0.0.2</runtimeVersion>
             </properties>
         </profile>
         <profile>
@@ -263,7 +263,7 @@
             <properties>
                 <runtimeGroupId>io.openliberty</runtimeGroupId>
                 <runtimeArtifactId>openliberty-runtime</runtimeArtifactId>
-                <runtimeVersion>22.0.0.9</runtimeVersion>
+                <runtimeVersion>23.0.0.3</runtimeVersion>
             </properties>
         </profile>
     </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 			<dependency>
 				<groupId>org.jboss.arquillian</groupId>
 				<artifactId>arquillian-bom</artifactId>
-				<version>1.7.0.Alpha14</version>
+				<version>1.7.0.Final</version>
 				<scope>import</scope>
 				<type>pom</type>
 			</dependency>
@@ -59,7 +59,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 
 		<liberty.arquillian.groupId>io.openliberty.arquillian</liberty.arquillian.groupId>
-		<liberty.arquillian.version>2.1.2</liberty.arquillian.version>
+		<liberty.arquillian.version>2.1.3</liberty.arquillian.version>
 		<liberty.managed.artifactId>arquillian-liberty-managed-jakarta</liberty.managed.artifactId>
 		<liberty.remote.artifactId>arquillian-liberty-remote-jakarta</liberty.remote.artifactId>
 


### PR DESCRIPTION
- Update liberty arquillian plugin to 2.1.3
- Update arquillian to 1.7.0.Final
- Update liberty gradle plugin to 3.6.1
- Update liberty maven plugin to 3.8.1
- Update open liberty to 23.0.0.3
- Update websphere liberty to 23.0.0.2 since it is the last version that has the ee9 archive install now that 23.0.0.3 supports EE 10
- Update README to include EE 10