### PR TITLE
Updates to use liberty arquillian 3.0.0-SNAPSHOT

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,14 +18,14 @@ jobs:
       max-parallel: 5
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java: [8, 11, 17]
+        java: [11, 17, 21]
 
     steps:
     - uses: actions/checkout@v3
     - name: Set up Maven
       uses: stCarolas/setup-maven@v4.2
       with:
-        maven-version: 3.8.1
+        maven-version: 3.9.2
     - name: Set up JDK
       uses: actions/setup-java@v3
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-*/build
+*/*/build/
 */.gradle
 target
 .DS_STORE

--- a/README.md
+++ b/README.md
@@ -35,7 +35,14 @@ In order to prevent dependency conflicts, you'll need to use the `arquillian-bom
 		<dependency>
 			<groupId>org.jboss.arquillian</groupId>
 			<artifactId>arquillian-bom</artifactId>
-			<version>1.7.0.Final</version>
+			<version>1.9.1.Final</version>
+			<scope>import</scope>
+			<type>pom</type>
+		</dependency>
+		<dependency>
+			<groupId>org.jboss.arquillian.jakarta</groupId>
+			<artifactId>arquillian-jakarta-bom</artifactId>
+			<version>10.0.0.Final</version>
 			<scope>import</scope>
 			<type>pom</type>
 		</dependency>
@@ -47,7 +54,7 @@ In order to prevent dependency conflicts, you'll need to use the `arquillian-bom
 	<dependency>
 		<groupId>io.openliberty.arquillian</groupId>
 		<artifactId>arquillian-liberty-managed-jakarta-junit</artifactId>
-		<version>2.1.4</version>
+		<version>3.0.0</version>
 		<type>pom</type>
 		<scope>test</scope>
 	</dependency>
@@ -114,12 +121,13 @@ Step 2: Apply the plugin:
 apply plugin: "io.spring.dependency-management"
 ```
 
-Step 3: Add a `dependencyManagement` block that contains the `arquillian-bom`:
+Step 3: Add a `dependencyManagement` block that contains the `arquillian-bom` and `arquillian-jakarta-bom`:
 
 ```
 dependencyManagement {
     imports {
-        mavenBom "org.jboss.arquillian:arquillian-bom:1.7.0.Final"
+        mavenBom "org.jboss.arquillian:arquillian-bom:1.9.1.Final"
+        mavenBom "org.jboss.arquillian.jakarta:arquillian-jakarta-bom:10.0.0.Final"
     }
 }
 ```

--- a/arquillian-liberty-managed-junit/pom.xml
+++ b/arquillian-liberty-managed-junit/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>io.openliberty.arquillian</groupId>
 		<artifactId>arquillian-liberty-jakarta-dependencies</artifactId>
-		<version>2.1.5-SNAPSHOT</version>
+		<version>3.0.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>arquillian-liberty-managed-jakarta-junit</artifactId>

--- a/arquillian-liberty-managed-junit5/pom.xml
+++ b/arquillian-liberty-managed-junit5/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>io.openliberty.arquillian</groupId>
 		<artifactId>arquillian-liberty-jakarta-dependencies</artifactId>
-		<version>2.1.5-SNAPSHOT</version>
+		<version>3.0.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>arquillian-liberty-managed-jakarta-junit5</artifactId>

--- a/arquillian-liberty-managed-testng/pom.xml
+++ b/arquillian-liberty-managed-testng/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>io.openliberty.arquillian</groupId>
 		<artifactId>arquillian-liberty-jakarta-dependencies</artifactId>
-		<version>2.1.5-SNAPSHOT</version>
+		<version>3.0.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>arquillian-liberty-managed-jakarta-testng</artifactId>

--- a/arquillian-liberty-remote-junit/pom.xml
+++ b/arquillian-liberty-remote-junit/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>io.openliberty.arquillian</groupId>
 		<artifactId>arquillian-liberty-jakarta-dependencies</artifactId>
-		<version>2.1.5-SNAPSHOT</version>
+		<version>3.0.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>arquillian-liberty-remote-jakarta-junit</artifactId>

--- a/arquillian-liberty-remote-junit5/pom.xml
+++ b/arquillian-liberty-remote-junit5/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>io.openliberty.arquillian</groupId>
 		<artifactId>arquillian-liberty-jakarta-dependencies</artifactId>
-		<version>2.1.5-SNAPSHOT</version>
+		<version>3.0.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>arquillian-liberty-remote-jakarta-junit5</artifactId>

--- a/arquillian-liberty-remote-testng/pom.xml
+++ b/arquillian-liberty-remote-testng/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>io.openliberty.arquillian</groupId>
 		<artifactId>arquillian-liberty-jakarta-dependencies</artifactId>
-		<version>2.1.5-SNAPSHOT</version>
+		<version>3.0.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>arquillian-liberty-remote-jakarta-testng</artifactId>

--- a/gradle-tests/build.gradle
+++ b/gradle-tests/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath group: 'io.openliberty.tools', name: 'liberty-gradle-plugin', version: '3.6.1'
+        classpath group: 'io.openliberty.tools', name: 'liberty-gradle-plugin', version: '3.9.1'
         classpath "io.spring.gradle:dependency-management-plugin:1.0.4.RELEASE"
     }
 }
@@ -23,7 +23,7 @@ subprojects {
             mavenCentral()
         }
         dependencies {
-            classpath group: 'io.openliberty.tools', name: 'liberty-gradle-plugin', version: '3.6.1'
+            classpath group: 'io.openliberty.tools', name: 'liberty-gradle-plugin', version: '3.9.1'
             classpath "io.spring.gradle:dependency-management-plugin:1.0.4.RELEASE"
         }
     }
@@ -44,10 +44,8 @@ subprojects {
         }
     }
 
-    project.buildDir = '../build'
-
-    sourceCompatibility = 1.8
-    targetCompatibility = 1.8
+    sourceCompatibility = 11
+    targetCompatibility = 11
     tasks.withType(JavaCompile) {
         options.encoding = 'UTF-8'
     }
@@ -66,7 +64,9 @@ subprojects {
 
     dependencyManagement {
         imports {
-            mavenBom "org.jboss.arquillian:arquillian-bom:1.7.0.Final"
+            mavenBom "org.jboss.arquillian:arquillian-bom:1.9.1.Final"
+            mavenBom "org.jboss.arquillian:arquillian-build:1.9.1.Final"
+            mavenBom "org.jboss.arquillian.jakarta:arquillian-jakarta-bom:10.0.0.Final"
         }
     }
 
@@ -74,6 +74,7 @@ subprojects {
         implementation ('jakarta.enterprise:jakarta.enterprise.cdi-api:3.0.0')
        
         testImplementation group: "io.openliberty.arquillian", name: "arquillian-liberty-managed-jakarta-junit", version: dependencyBundleVersion
+        testImplementation group: "junit", name: "junit", version: "4.13.2"
         testImplementation ('org.jboss.shrinkwrap:shrinkwrap-api')
         testImplementation files("${System.properties['java.home']}/../lib/tools.jar")
     }

--- a/gradle-tests/gradle.properties
+++ b/gradle-tests/gradle.properties
@@ -1,1 +1,1 @@
-dependencyBundleVersion=2.1.4-SNAPSHOT
+dependencyBundleVersion=3.0.0-SNAPSHOT

--- a/gradle-tests/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle-tests/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/it/managed-tests/pom.xml
+++ b/it/managed-tests/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>io.openliberty.tools</groupId>
         <artifactId>liberty-maven-app-parent</artifactId>
-        <version>3.8.1</version>
+        <version>3.11.1</version>
     </parent>
 
     <licenses>
@@ -46,8 +46,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
 
         <!-- Liberty server properties -->
         <wlpServerName>LibertyProjectServer</wlpServerName>
@@ -62,7 +63,21 @@
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
-                <version>1.7.0.Final</version>
+                <version>1.9.1.Final</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-build</artifactId>
+                <version>1.9.1.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.arquillian.jakarta</groupId>
+                <artifactId>arquillian-jakarta-bom</artifactId>
+                <version>10.0.0.Final</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -88,12 +103,18 @@
             <artifactId>shrinkwrap-api</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
     <build>
         <plugins>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.2.5</version>
                 <executions>
                     <execution>
                         <id>default-integration-test</id>
@@ -145,7 +166,6 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.1</version>
                 <extensions>true</extensions>
                 <!-- Specify configuration, executions for liberty-maven-plugin -->
                 <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.openliberty.arquillian</groupId>
 	<artifactId>arquillian-liberty-jakarta-dependencies</artifactId>
-	<version>2.1.5-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Arquillian Liberty Jakarta Dependency Bundles</name>
 
@@ -34,7 +34,21 @@
 			<dependency>
 				<groupId>org.jboss.arquillian</groupId>
 				<artifactId>arquillian-bom</artifactId>
-				<version>1.7.0.Final</version>
+				<version>1.9.1.Final</version>
+				<scope>import</scope>
+				<type>pom</type>
+			</dependency>
+			<dependency>
+				<groupId>org.jboss.arquillian</groupId>
+				<artifactId>arquillian-build</artifactId>
+				<version>1.9.1.Final</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.jboss.arquillian.jakarta</groupId>
+				<artifactId>arquillian-jakarta-bom</artifactId>
+				<version>10.0.0.Final</version>
 				<scope>import</scope>
 				<type>pom</type>
 			</dependency>
@@ -55,16 +69,17 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.release>11</maven.compiler.release>
+		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>11</maven.compiler.target>
 
 		<liberty.arquillian.groupId>io.openliberty.arquillian</liberty.arquillian.groupId>
-		<liberty.arquillian.version>2.1.3</liberty.arquillian.version>
+		<liberty.arquillian.version>3.0.0-SNAPSHOT</liberty.arquillian.version>
 		<liberty.managed.artifactId>arquillian-liberty-managed-jakarta</liberty.managed.artifactId>
 		<liberty.remote.artifactId>arquillian-liberty-remote-jakarta</liberty.remote.artifactId>
 
 		<junit.version>4.13.2</junit.version>
-		<junit5.version>5.9.0</junit5.version>
+		<junit5.version>5.11.2</junit5.version>
 		<testng.version>7.5.1</testng.version>
 	</properties>
 


### PR DESCRIPTION
- Consistently use the same gradle plugin version
- Update to use Java 11 target
- Update to Arquillian 1.9.1.Final to match liberty arquillian 3.0.0
- Update to latest gradle level and fix up build.gradle to get it working with newer gradle version
- Update workflow to do 11, 17 and 21 instead of 8, 11 and 17